### PR TITLE
About Page Editorial Categories + Dev/UX title change

### DIFF
--- a/src/Pages/AboutProject/MeetTheTeam/MeetTheTeam.js
+++ b/src/Pages/AboutProject/MeetTheTeam/MeetTheTeam.js
@@ -33,7 +33,7 @@ function MeetTheTeam() {
     "EducatorCollaborators": 'EDUCATOR COLLABORATORS',
     "ContentResearchAssistants": 'CONTENT RESEARCH ASSISTANTS',
     "ContentInterns": 'CONTENT INTERNS',
-    "DevUXInterns": 'FULL-STACK DEV AND UX INTERNS',
+    "DevUXInterns": 'FULL-STACK DEV AND UX INTERNS/STAFF',
     "InauguralTeam": 'INAUGURAL TEAM',
     "SteeringCommittee": 'STEERING COMMITTEE',
     "InternalAdvisoryCommittee": 'INTERNAL ADVISORY COMMITTEE',

--- a/src/Pages/AboutProject/MeetTheTeam/MeetTheTeam.js
+++ b/src/Pages/AboutProject/MeetTheTeam/MeetTheTeam.js
@@ -39,6 +39,8 @@ function MeetTheTeam() {
     "InternalAdvisoryCommittee": 'INTERNAL ADVISORY COMMITTEE',
     "ExternalAdvisoryCommittee": 'EXTERNAL ADVISORY COMMITTEE',
     "DonorGrantingAgencies": 'DONOR AND GRANTING AGENCIES',
+    "EditorialBoardFellows": 'EDITORIAL BOARD FELLOWS',
+    "EditorialBoardLeads": 'EDITORIAL BOARD LEADS'
   }; 
 
   useEffect(() => {


### PR DESCRIPTION
This PR contains the following ClickUp Tasks:

1. About project page: change title for Full Stack UX to read as follows: Full-Stack Dev and UX Interns/Staff
2. About: Add category as follows: Editorial Board Fellows. Use the model of Student Collaborators.
3. About project page: change title for Full Stack UX to read as follows: Full-Stack Dev and UX Interns/Staff